### PR TITLE
Refactor LED matrix demo for NeoPixel matrix

### DIFF
--- a/education/2025/arduino/README.md
+++ b/education/2025/arduino/README.md
@@ -1,6 +1,6 @@
 # Arduino Nano ESP32 8x8 LED Matrix Demo
 
-This example sketch drives a classic 8x8 LED matrix directly from an **Arduino Nano ESP32**, multiplexing the rows and columns to create an eye-catching animation loop. Three scenes run in sequence:
+This example sketch drives a classic 8x8 **NeoPixel-compatible** LED matrix from an Arduino Nano ESP32. Three scenes run in sequence:
 
 1. **Spiral comet** that traces the perimeter and then dives toward the center.
 2. **Ocean wave** made from sine curves sweeping across the grid.
@@ -8,31 +8,32 @@ This example sketch drives a classic 8x8 LED matrix directly from an **Arduino N
 
 ## Hardware assumptions
 
-- An 8x8 LED matrix wired with its **rows on the anode side** and **columns on the cathode side** (common-cathode columns).
-- Each row and column line is connected through an appropriate current-limiting resistor or driver stage.
-- The matrix is multiplexed directly from 16 GPIO pins of the Nano ESP32. Adjust the `rowPins` and `colPins` arrays in `nano_esp32_led_matrix.ino` if you use different wiring or transistor drivers.
-
-> 💡 If your matrix is wired the opposite way (common-cathode rows / common-anode columns), invert the logic inside `refreshDisplay()` so that the active row is driven LOW and active columns are driven HIGH.
+- The matrix is built from WS2812, SK6812, or another single-wire addressable LED technology (three-pin connector: 5V, GND, DIN).
+- The matrix is arranged as an 8×8 serpentine grid where neighbouring columns run in opposite directions. If your wiring differs, adjust `xyToIndex()` inside `nano_esp32_led_matrix.ino`.
+- A common 5 V supply powers both the board and the matrix. Make sure to connect the grounds.
 
 ## Wiring reference
 
 | Matrix connection | Nano ESP32 pin (default) |
 |-------------------|---------------------------|
-| Rows R0..R7       | D2, D3, D4, D5, D6, D7, D8, D9 |
-| Columns C0..C7    | D10, D11, D12, D13, A0, A1, A2, A3 |
+| DIN               | D6                        |
+| 5V                | 5V                        |
+| GND               | GND                       |
 
-Feel free to remap these pins to match your build. Keep the row set on one side of the board and the column set on the other to simplify the refresh routine.
+Feel free to move the data line to another digital-capable pin by changing `DATA_PIN` in `nano_esp32_led_matrix.ino`.
 
-## Uploading the sketch
+## Software setup
 
-1. Open `nano_esp32_led_matrix.ino` in the Arduino IDE or Arduino CLI environment.
-2. Select **Arduino Nano ESP32** as the target board and choose the correct serial port.
-3. Compile and upload. Once the board resets you should see the animation cycle endlessly.
+1. Install the **Adafruit NeoPixel** library (Sketch → Include Library → Manage Libraries… → search for “Adafruit NeoPixel”).
+2. Open `nano_esp32_led_matrix.ino` in the Arduino IDE or Arduino CLI environment.
+3. Select **Arduino Nano ESP32** as the target board and choose the correct serial port.
+4. Compile and upload. Once the board resets you should see the animation cycle endlessly.
 
 ## Customizing the show
 
-- **Brightness**: change `ROW_HOLD_MICROS`. Longer hold times increase brightness but can introduce flicker.
-- **Animation speed**: tweak the timing constants inside `runAnimation()` (e.g., 80 ms for the spiral step, 60 ms for the wave step).
+- **Brightness**: adjust `strip.setBrightness()` in `setup()`. Lower values reduce current draw.
+- **Data pin**: change the `DATA_PIN` constant if you wired the matrix to a different IO.
+- **Orientation**: edit `xyToIndex()` to match your panel’s wiring pattern.
 - **Effects**: add your own scene by extending the `AnimationPhase` enum and adding a new renderer.
 
 Enjoy turning the 8x8 grid into a mini light show!


### PR DESCRIPTION
## Summary
- refactor the Arduino sketch to drive an 8x8 NeoPixel-style matrix from a single data pin
- add serpentine coordinate mapping and color-aware animations suited to addressable LEDs
- update the README with three-wire wiring guidance and Adafruit NeoPixel library setup steps

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf39dfb17c83258503bad815b37173