### PR TITLE
Add French translation of environment overview

### DIFF
--- a/education/2025/03_Environments/environment_overview.fr.md
+++ b/education/2025/03_Environments/environment_overview.fr.md
@@ -1,0 +1,48 @@
+# Environnements de développement pour ce cours
+
+L'ensemble des outils de ce cours s'articule autour de **Visual Studio Code (VS Code)**. Que vous travailliez entièrement dans le cloud ou sur votre propre matériel, nous comptons sur l'interface cohérente de VS Code, ses extensions et son terminal intégré pour maintenir des habitudes de travail familières.
+
+## Codespaces (point de départ principal)
+- **Ce que c'est :** GitHub Codespaces fournit un environnement de développement hébergé dans le cloud qui se lance directement depuis votre dépôt.
+- **Pourquoi nous l'utilisons en premier :**
+  - Mise à disposition instantanée avec VS Code dans le navigateur ou l'application de bureau.
+  - Configuration identique pour chaque étudiant, ce qui minimise les problèmes d'installation.
+  - Ressources de calcul intégrées et outils préconfigurés adaptés à ce programme.
+- **Rôle dans le cours :** Tous les exercices et exemples initiaux partent du principe que vous travaillez dans un Codespace afin que nous puissions entrer rapidement dans le contenu sans perdre de temps sur la configuration locale.
+
+## Windows 11 avec VS Code Desktop
+- **Ce que c'est :** Développer directement sur une installation Windows 11 en utilisant l'application VS Code native.
+- **Points d'attention :**
+  - Certains outils en ligne de commande se comportent différemment par rapport aux environnements de type Unix.
+  - Nécessite l'installation manuelle des langages et des outils.
+  - Convient bien pour les outils graphiques ou les flux de travail spécifiques à Windows.
+- **Contexte du cours :** Bien que Windows 11 puisse héberger VS Code confortablement, nous recommandons de l'associer à Windows Subsystem for Linux (WSL) pour se rapprocher des instructions basées sur Linux utilisées tout au long du cours.
+
+## Windows Subsystem for Linux (WSL) sur Windows 11
+- **Ce que c'est :** Un environnement Linux virtualisé léger qui s'exécute parallèlement à Windows et reste accessible directement depuis VS Code.
+- **Avantages :**
+  - Offre une véritable expérience de ligne de commande Linux sans quitter Windows.
+  - S'intègre étroitement à VS Code via les extensions Remote Development.
+  - Prend en charge les mêmes outils et scripts que nous utilisons dans Codespaces, ce qui rend la transition transparente.
+- **Feuille de route du cours :** Après vous être familiarisé avec Codespaces, nous vous guiderons dans la configuration de WSL afin que vous puissiez reproduire les mêmes flux de travail en local tout en profitant de Windows pour les tâches quotidiennes.
+
+## Distribution Linux native
+- **Ce que c'est :** Installer VS Code sur une distribution Linux dédiée telle qu'Ubuntu, Fedora ou Debian.
+- **Points forts :**
+  - Contrôle maximal de l'environnement système avec un accès direct aux outils Linux.
+  - Souvent privilégié par les utilisateurs avancés qui souhaitent une personnalisation complète et une utilisation efficace des ressources.
+- **Point de vue du cours :** Cette option reflète les environnements utilisés dans l'industrie et dans Codespaces. Vous êtes libre d'utiliser un système Linux natif si vous en disposez déjà, mais les instructions d'intégration se concentreront sur Codespaces et WSL.
+
+## macOS avec VS Code
+- **Ce que c'est :** Exécuter VS Code sur macOS avec le terminal de type Unix intégré et sa chaîne d'outils.
+- **Points clés :**
+  - Excellente prise en charge de la ligne de commande via zsh et Homebrew pour la gestion des paquets.
+  - Performances fluides sur Apple Silicon et forte intégration avec les fonctionnalités de macOS.
+- **Point de vue du cours :** macOS peut suivre la plupart des instructions orientées Linux avec des ajustements mineurs. Vous pouvez utiliser macOS s'il s'agit de votre machine principale, même si les démonstrations officielles continueront de se concentrer sur Codespaces et WSL afin de conserver une cohérence au sein de la cohorte.
+
+## Résumé de la progression
+1. **Commencez dans Codespaces** afin que chacun dispose du même environnement de base et des mêmes outils dans VS Code.
+2. **Passez à WSL sur Windows 11** dès que vous êtes prêt à reproduire localement le flux de travail basé sur Linux.
+3. **Explorez les configurations Linux natives ou macOS** si vous avez besoin de flexibilité supplémentaire ou si vous maîtrisez déjà la gestion de ces systèmes.
+
+En standardisant notre travail sur VS Code et en définissant clairement nos environnements cibles, nous pouvons consacrer plus de temps à maîtriser le contenu du cours et moins de temps à résoudre des problèmes de configuration locale.

--- a/education/2025/03_Environments/environment_overview.md
+++ b/education/2025/03_Environments/environment_overview.md
@@ -1,0 +1,48 @@
+# Development Environments for This Course
+
+Our tooling for the entire course revolves around **Visual Studio Code (VS Code)**. Whether you are working entirely in the cloud or on your own hardware, we will rely on VS Code's consistent interface, extensions, and integrated terminal to keep every workflow familiar.
+
+## Codespaces (Primary Starting Point)
+- **What it is:** GitHub Codespaces provides a cloud-hosted development environment that launches directly from your repository.
+- **Why we use it first:**
+  - Instant provisioning with VS Code in the browser or the desktop application.
+  - Identical configuration for every student, minimizing setup issues.
+  - Built-in compute resources and preconfigured tooling tailored for this curriculum.
+- **How it fits the course:** All initial exercises and examples assume you are working inside a Codespace so we can move quickly into the material without spending time on local setup.
+
+## Windows 11 with VS Code Desktop
+- **What it is:** Developing directly on a Windows 11 installation using the native VS Code application.
+- **Considerations:**
+  - Some command-line tools behave differently compared to Unix-like environments.
+  - Requires you to install language runtimes and tooling manually.
+  - Works well for graphical tools or Windows-specific workflows.
+- **Course context:** While Windows 11 can host VS Code comfortably, we encourage pairing it with Windows Subsystem for Linux (WSL) to more closely mirror the Linux-based instructions used throughout the course.
+
+## Windows Subsystem for Linux (WSL) on Windows 11
+- **What it is:** A lightweight virtualized Linux environment running alongside Windows, accessible directly from VS Code.
+- **Benefits:**
+  - Provides a genuine Linux command-line experience without leaving Windows.
+  - Integrates tightly with VS Code through the Remote Development extensions.
+  - Supports the same tooling and scripts we use in Codespaces, making transitions seamless.
+- **Course roadmap:** After you are comfortable in Codespaces, we will guide you through setting up WSL so you can reproduce the same workflows locally while leveraging Windows for everyday tasks.
+
+## Native Linux Distribution
+- **What it is:** Installing VS Code on a dedicated Linux distribution such as Ubuntu, Fedora, or Debian.
+- **Strengths:**
+  - Maximum control over the system environment with direct access to Linux tooling.
+  - Often preferred for advanced users who want full customization and resource efficiency.
+- **Course perspective:** This option mirrors the environments used in industry and in Codespaces. You are welcome to use a native Linux system if you already have one, but onboarding instructions will center on Codespaces and WSL.
+
+## macOS with VS Code
+- **What it is:** Running VS Code on macOS with the built-in Unix-like terminal and toolchain.
+- **Highlights:**
+  - Strong command-line support via zsh and Homebrew for package management.
+  - Smooth performance on Apple Silicon and deep integration with macOS features.
+- **Course perspective:** macOS can follow most Linux-oriented instructions with minor adjustments. You may use macOS if it is your primary machine, though the official walkthroughs will still focus on Codespaces and WSL to maintain parity across the cohort.
+
+## Progression Summary
+1. **Start in Codespaces** to ensure everyone has the same baseline environment and tooling inside VS Code.
+2. **Transition to WSL on Windows 11** once you are ready to mirror the Linux-based workflow locally.
+3. **Explore native Linux or macOS** setups if you need additional flexibility or already have experience managing those systems.
+
+By standardizing on VS Code and clearly defining our target environments, we can spend more time mastering the course material and less time troubleshooting local configuration issues.


### PR DESCRIPTION
## Summary
- add a French-language version of the development environment overview for the 2025 curriculum module
- mirror the structure and focus on Visual Studio Code and the Codespaces-to-WSL progression in the translation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cfe80bdb40832589606a18ea279967